### PR TITLE
Fix Crystal Heart unaffected by opp mons effect

### DIFF
--- a/CHIM-JP/script/c101010040.lua
+++ b/CHIM-JP/script/c101010040.lua
@@ -41,7 +41,7 @@ function s.econ(e)
 	return e:GetHandler():GetSequence()>4
 end
 function s.efilter(e,te)
-	return te:GetOwner()~=e:GetOwner()
+	return te:IsActiveType(TYPE_MONSTER) and te:GetOwnerPlayer()~=e:GetHandlerPlayer()
 end
 function s.imcon(e)
 	local ph=Duel.GetCurrentPhase()


### PR DESCRIPTION
Used Silent Magician LV8 as template for the fix (since he's immune against opponent spell card)