### PR TITLE
Added prototype handling of "Curse of the Shadow Prison"

### DIFF
--- a/SD37 - 1003370XX/fusion/c24094653.lua
+++ b/SD37 - 1003370XX/fusion/c24094653.lua
@@ -1,0 +1,91 @@
+--融合
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.activate)
+	c:RegisterEffect(e1)
+end
+function s.filter1(c,e)
+	return not c:IsImmuneToEffect(e)
+end
+function s.filter2(c,e,tp,m,f,chkf)
+	return c:IsType(TYPE_FUSION) and (not f or f(c))
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local chkf=tp
+		local mg1=Duel.GetFusionMaterial(tp)
+		local res=Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		if not res then
+			local ce=Duel.GetChainMaterial(tp)
+			if ce~=nil then
+				local fgroup=ce:GetTarget()
+				local mg2=fgroup(ce,e,tp)
+				local mf=ce:GetValue()
+				local oldcheck=aux.FCheckAdditional
+				local fcheck=nil
+				if ce:GetLabelObject() then fcheck=ce:GetLabelObject():GetOperation() end
+				if fcheck then 
+					if oldcheck then aux.FCheckAdditional=aux.AND(oldcheck,fcheck) else aux.FCheckAdditional=fcheck end
+				end
+				res=Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				aux.FCheckAdditional=oldcheck
+			end
+		end
+		return res
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local chkf=tp
+	local mg1=Duel.GetFusionMaterial(tp):Filter(s.filter1,nil,e)
+	local sg1=Duel.GetMatchingGroup(s.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	local mg2=nil
+	local sg2=nil
+	local ce=Duel.GetChainMaterial(tp)
+	if ce~=nil then
+		local fgroup=ce:GetTarget()
+		mg2=fgroup(ce,e,tp)
+		local mf=ce:GetValue()
+		local oldcheck=aux.FCheckAdditional
+		local fcheck=nil
+		if ce:GetLabelObject() then fcheck=ce:GetLabelObject():GetOperation() end
+		if fcheck then 
+			if oldcheck then aux.FCheckAdditional=aux.AND(oldcheck,fcheck) else aux.FCheckAdditional=fcheck end
+		end
+		sg2=Duel.GetMatchingGroup(s.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		aux.FCheckAdditional=oldcheck
+	end
+	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
+		local sg=sg1:Clone()
+		if sg2 then sg:Merge(sg2) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tg=sg:Select(tp,1,1,nil)
+		local tc=tg:GetFirst()
+		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			tc:SetMaterial(mat1)
+			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+			Duel.BreakEffect()
+			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
+		else
+			local oldcheck=aux.FCheckAdditional
+			local fcheck=nil
+			if ce:GetLabelObject() then fcheck=ce:GetLabelObject():GetOperation() end
+			if fcheck then 
+				if oldcheck then aux.FCheckAdditional=aux.AND(oldcheck,fcheck) else aux.FCheckAdditional=fcheck end
+			end
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			aux.FCheckAdditional=oldcheck
+			local fop=ce:GetOperation()
+			fop(ce,e,tp,tc,mat2)
+		end
+		tc:CompleteProcedure()
+	end
+end

--- a/SD37 - 1003370XX/fusion/c81788994.lua
+++ b/SD37 - 1003370XX/fusion/c81788994.lua
@@ -1,0 +1,87 @@
+--影牢の呪縛
+local s,id=GetID()
+function s.initial_effect(c)
+	c:EnableCounterPermit(0x16)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--counter
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetRange(LOCATION_FZONE)
+	e2:SetCondition(s.ctcon)
+	e2:SetOperation(s.ctop)
+	c:RegisterEffect(e2)
+	--atkdown
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetTargetRange(0,LOCATION_MZONE)
+	e3:SetCondition(s.atkcon)
+	e3:SetValue(s.atkval)
+	c:RegisterEffect(e3)
+	--
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(id,0))
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_CHAIN_MATERIAL)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetRange(LOCATION_FZONE)
+	e4:SetTargetRange(1,0)
+	e4:SetCondition(s.chcon)
+	e4:SetTarget(s.chtg)
+	e4:SetOperation(s.chop)
+	e4:SetValue(aux.FilterBoolFunction(Card.IsSetCard,0x9d))
+	c:RegisterEffect(e4)
+	local e5=Effect.CreateEffect(c)
+	e5:SetOperation(s.chk)
+	e4:SetLabelObject(e5)
+end
+s.listed_series={0x9d}
+function s.cfilter(c)
+	return c:IsSetCard(0x9d) and c:IsType(TYPE_MONSTER) and c:IsReason(REASON_EFFECT)
+end
+function s.ctcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.cfilter,1,nil)
+end
+function s.ctop(e,tp,eg,ep,ev,re,r,rp)
+	local ct=eg:FilterCount(s.cfilter,nil)
+	e:GetHandler():AddCounter(0x16,ct)
+end
+function s.atkcon(e)
+	return Duel.GetTurnPlayer()~=e:GetHandlerPlayer()
+end
+function s.atkval(e,c)
+	return e:GetHandler():GetCounter(0x16)*-100
+end
+function s.chcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetCounter(0x16)>=3
+end
+function s.chfilter(c,e,tp)
+	return c:IsType(TYPE_MONSTER) and (c:IsFaceup() or c:IsControler(tp)) and c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+end
+function s.chtg(e,te,tp)
+	return Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,te,tp)
+end
+function s.chop(e,te,tp,tc,mat,sumtype,sg)
+	if not sumtype then sumtype=SUMMON_TYPE_FUSION end
+	tc:SetMaterial(mat)
+	Duel.SendtoGrave(mat,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+	if mat:IsExists(Card.IsControler,1,nil,1-tp) then
+		e:GetHandler():RemoveCounter(tp,0x16,3,REASON_EFFECT)
+	end
+	Duel.BreakEffect()
+	if sg then
+		sg:AddCard(tc)
+	else
+		Duel.SpecialSummon(tc,sumtype,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function s.chk(tp,sg,fc)
+	return sg:FilterCount(Card.IsControler,nil,1-tp)<=1
+end


### PR DESCRIPTION
Explanation of the changes:
- The effect of "Curse of the Shadow Prison" that lets you use an opponent's monster as material is now handled through EFFECT_CHAIN_MATERIAL. Most of the handling is identical to "Cybernetic Fusion Support" and similar, with the significant different being the addition of an effect as LabelObject. This effect will include the handling for Auxiliary.FCheckAdditional in its operation (in theory we can put the handling of Auxiliary.FCheckExact in its value, but it's not implemented right now).
- The effect of "Polymerization" has been updated, in the part related to the chain materials, so that it also checks whether the chain effect would also change the additional checks: if so, Auxiliary.FCheckAdditional is temporarily merged with the chain check during material check and selection only. The same extra lines will need to be added to all potential Fusion Summon effects, to ensure they can all handle the check: for simplicity's sake, it'd be better to limit ourselves to cards that can feasably be used to make Apkalone, since the handling can be simplified with future procedures.