### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Supported editors like VSCode will now use tabs in general, only using spaces for JavaScript
GitHub will display tabs as 2-wide to distinguish from accidental 4-space indents; 8-wide tabs in the editor hurt a lot